### PR TITLE
pygobject 2.28.6: add patch

### DIFF
--- a/pygobject/patch-enum-types.diff
+++ b/pygobject/patch-enum-types.diff
@@ -1,0 +1,50 @@
+From 42d01f060c5d764baa881d13c103d68897163a49 Mon Sep 17 00:00:00 2001
+From: Ryan Lortie <desrt@desrt.ca>
+Date: Mon, 12 Mar 2012 16:44:14 -0400
+Subject: gio-types.defs: change some enums to flags
+
+These flags types were originally incorrectly handled in glib as being
+enums.  That bug was fixed, but they're still enums here, leading to
+warnings about the mismatch.
+
+Change them to flags.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=668522
+---
+ gio/gio-types.defs | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/gio/gio-types.defs b/gio/gio-types.defs
+index 331e0bc..7eee5c8 100644
+--- a/gio/gio-types.defs
++++ b/gio/gio-types.defs
+@@ -526,7 +526,7 @@
+   )
+ )
+ 
+-(define-enum MountMountFlags
++(define-flags MountMountFlags
+   (in-module "gio")
+   (c-name "GMountMountFlags")
+   (gtype-id "G_TYPE_MOUNT_MOUNT_FLAGS")
+@@ -545,7 +545,7 @@
+   )
+ )
+ 
+-(define-enum DriveStartFlags
++(define-flags DriveStartFlags
+   (in-module "gio")
+   (c-name "GDriveStartFlags")
+   (gtype-id "G_TYPE_DRIVE_START_FLAGS")
+@@ -770,7 +770,7 @@
+   )
+ )
+ 
+-(define-enum SocketMsgFlags
++(define-flags SocketMsgFlags
+   (in-module "gio")
+   (c-name "GSocketMsgFlags")
+   (gtype-id "G_TYPE_SOCKET_MSG_FLAGS")
+-- 
+cgit v0.11.2
+


### PR DESCRIPTION
As proposed by https://github.com/Homebrew/homebrew/pull/44629, I am
submitting this patch here.

The patch hash changed over time, but according to the bug history (form where
this patch originates) nothing has changed. As a result, building pygobject
is/was not possible. When this patch gets merged, I will update the formula PR.

This patch is a direct download of the patch URL in the [Formula](https://github.com/Homebrew/homebrew/blob/7506f7703a50ad0909edbb7afec6f68192774759/Library/Formula/pygobject.rb).