### PR TITLE
mplayer: same libvpx patch used in ffmpeg.rb

### DIFF
--- a/mplayer/libvpx-1.5.0.patch
+++ b/mplayer/libvpx-1.5.0.patch
@@ -1,0 +1,41 @@
+From 6540fe04a3f9a11ba7084a49b3ee5fa2fc5b32ab Mon Sep 17 00:00:00 2001
+From: James Zern <jzern@google.com>
+Date: Mon, 19 Oct 2015 22:44:11 -0700
+Subject: [PATCH] libvpxenc: remove some unused ctrl id mappings
+
+VP8E_UPD_ENTROPY, VP8E_UPD_REFERENCE, VP8E_USE_REFERENCE were removed
+from libvpx and the remaining values were never used here
+
+Reviewed-by: Michael Niedermayer <michael@niedermayer.cc>
+Signed-off-by: James Zern <jzern@google.com>
+---
+ ffmpeg/libavcodec/libvpxenc.c |    8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/ffmpeg/libavcodec/libvpxenc.c b/ffmpeg/libavcodec/libvpxenc.c
+index 5f39783..992122c 100644
+--- a/ffmpeg/libavcodec/libvpxenc.c
++++ b/ffmpeg/libavcodec/libvpxenc.c
+@@ -104,19 +104,11 @@ typedef struct VP8EncoderContext {
+ 
+ /** String mappings for enum vp8e_enc_control_id */
+ static const char *const ctlidstr[] = {
+-    [VP8E_UPD_ENTROPY]           = "VP8E_UPD_ENTROPY",
+-    [VP8E_UPD_REFERENCE]         = "VP8E_UPD_REFERENCE",
+-    [VP8E_USE_REFERENCE]         = "VP8E_USE_REFERENCE",
+-    [VP8E_SET_ROI_MAP]           = "VP8E_SET_ROI_MAP",
+-    [VP8E_SET_ACTIVEMAP]         = "VP8E_SET_ACTIVEMAP",
+-    [VP8E_SET_SCALEMODE]         = "VP8E_SET_SCALEMODE",
+     [VP8E_SET_CPUUSED]           = "VP8E_SET_CPUUSED",
+     [VP8E_SET_ENABLEAUTOALTREF]  = "VP8E_SET_ENABLEAUTOALTREF",
+     [VP8E_SET_NOISE_SENSITIVITY] = "VP8E_SET_NOISE_SENSITIVITY",
+-    [VP8E_SET_SHARPNESS]         = "VP8E_SET_SHARPNESS",
+     [VP8E_SET_STATIC_THRESHOLD]  = "VP8E_SET_STATIC_THRESHOLD",
+     [VP8E_SET_TOKEN_PARTITIONS]  = "VP8E_SET_TOKEN_PARTITIONS",
+-    [VP8E_GET_LAST_QUANTIZER]    = "VP8E_GET_LAST_QUANTIZER",
+     [VP8E_SET_ARNR_MAXFRAMES]    = "VP8E_SET_ARNR_MAXFRAMES",
+     [VP8E_SET_ARNR_STRENGTH]     = "VP8E_SET_ARNR_STRENGTH",
+     [VP8E_SET_ARNR_TYPE]         = "VP8E_SET_ARNR_TYPE",
+-- 
+1.7.10.4
+


### PR DESCRIPTION
Fix build with libvpx 1.5.0, see https://trac.ffmpeg.org/ticket/4956
https://github.com/UniqMartin/homebrew/commit/e11af1893f46e3c8997205ecbff0a73674b18d23