### PR TITLE
libspatialite: upstream patch for >=sqlite 3.10

### DIFF
--- a/libspatialite/sqlite310.patch
+++ b/libspatialite/sqlite310.patch
@@ -1,0 +1,160 @@
+diff --git a/config.h.in b/config.h.in
+index 268e638..2c7d98f 100644
+--- a/config.h.in
++++ b/config.h.in
+@@ -18,6 +18,9 @@
+ /* Should be defined in order to enable GEOS_TRUNK experimental support. */
+ #undef GEOS_TRUNK
+ 
++/* depending on SQLite library version. */
++#undef HAVE_DECL_SQLITE_INDEX_CONSTRAINT_LIKE
++
+ /* Define to 1 if you have the <dlfcn.h> header file. */
+ #undef HAVE_DLFCN_H
+ 
+diff --git a/configure b/configure
+index aafdad5..72e8c94 100755
+--- a/configure
++++ b/configure
+@@ -2108,6 +2108,52 @@ $as_echo "$ac_res" >&6; }
+   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+ 
+ } # ac_fn_c_check_type
++
++# ac_fn_c_check_decl LINENO SYMBOL VAR INCLUDES
++# ---------------------------------------------
++# Tests whether SYMBOL is declared in INCLUDES, setting cache variable VAR
++# accordingly.
++ac_fn_c_check_decl ()
++{
++  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
++  as_decl_name=`echo $2|sed 's/ *(.*//'`
++  as_decl_use=`echo $2|sed -e 's/(/((/' -e 's/)/) 0&/' -e 's/,/) 0& (/g'`
++  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $as_decl_name is declared" >&5
++$as_echo_n "checking whether $as_decl_name is declared... " >&6; }
++if eval \${$3+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++$4
++int
++main ()
++{
++#ifndef $as_decl_name
++#ifdef __cplusplus
++  (void) $as_decl_use;
++#else
++  (void) $as_decl_name;
++#endif
++#endif
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"; then :
++  eval "$3=yes"
++else
++  eval "$3=no"
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++fi
++eval ac_res=\$$3
++	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
++$as_echo "$ac_res" >&6; }
++  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
++
++} # ac_fn_c_check_decl
+ cat >config.log <<_ACEOF
+ This file contains any messages produced by compilers while
+ running configure, to aid debugging if configure makes a mistake.
+@@ -18617,6 +18663,14 @@ else
+ fi
+ 
+ 
++ac_fn_c_check_decl "$LINENO" "SQLITE_INDEX_CONSTRAINT_LIKE" "ac_cv_have_decl_SQLITE_INDEX_CONSTRAINT_LIKE" "#include <sqlite3.h>
++"
++if test "x$ac_cv_have_decl_SQLITE_INDEX_CONSTRAINT_LIKE" = xyes; then :
++  $as_echo "#define HAVE_DECL_SQLITE_INDEX_CONSTRAINT_LIKE 1" >>confdefs.h
++
++fi
++
++
+ cat >confcache <<\_ACEOF
+ # This file is a shell script that caches the results of configure
+ # tests run on this system so they can be shared between configure
+diff --git a/configure.ac b/configure.ac
+index 06ebe98..178036f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -57,6 +57,8 @@ AH_TEMPLATE([POSTGIS_2_1],
+             [Should be defined when linking liblwgeom from PostGIS 2.1 (or later).])
+ AH_TEMPLATE([TARGET_CPU],
+             [Should contain a text-string describing the intended target CPU])
++AH_TEMPLATE([HAVE_DECL_SQLITE_INDEX_CONSTRAINT_LIKE],
++            [depending on SQLite library version.])
+ 
+ # Checks for header files.
+ AC_CHECK_HEADERS(stdlib.h,, [AC_MSG_ERROR([cannot find stdlib.h, bailing out])])
+@@ -380,6 +382,9 @@ AM_CONDITIONAL([MACOSX], [test "$target_alias" = "macosx"])
+ # Checking for Android
+ AM_CONDITIONAL([ANDROID], [test "$target_alias" = "android"])
+ 
++AC_CHECK_DECL([SQLITE_INDEX_CONSTRAINT_LIKE],
++  [AC_DEFINE(HAVE_DECL_SQLITE_INDEX_CONSTRAINT_LIKE)],[],[[#include <sqlite3.h>]])
++
+ AC_OUTPUT
+ 
+ #-----------------------------------------------------------------------
+diff --git a/src/spatialite/virtualXL.c b/src/spatialite/virtualXL.c
+index dcc7d80..df8b809 100644
+--- a/src/spatialite/virtualXL.c
++++ b/src/spatialite/virtualXL.c
+@@ -690,6 +690,12 @@ vXL_eval_constraints (VirtualXLCursorPtr cursor)
+ 		      if (ret >= 0)
+ 			  ok = 1;
+ 		      break;
++#ifdef HAVE_DECL_SQLITE_INDEX_CONSTRAINT_LIKE
++case SQLITE_INDEX_CONSTRAINT_LIKE:
++					      if (ret >= 0)
++				ok = 1;
++			    break;
++#endif
+ 		  };
+ 	    }
+ 	done:
+diff --git a/src/spatialite/virtualdbf.c b/src/spatialite/virtualdbf.c
+index 9ac3644..1a9b67f 100644
+--- a/src/spatialite/virtualdbf.c
++++ b/src/spatialite/virtualdbf.c
+@@ -661,6 +661,12 @@ vdbf_eval_constraints (VirtualDbfCursorPtr cursor)
+ 					      if (ret >= 0)
+ 						  ok = 1;
+ 					      break;
++#ifdef HAVE_DECL_SQLITE_INDEX_CONSTRAINT_LIKE
++					  case SQLITE_INDEX_CONSTRAINT_LIKE:
++					      if (ret >= 0)
++						  ok = 1;
++					      break;
++#endif
+ 					  };
+ 				    }
+ 				  break;
+diff --git a/src/spatialite/virtualshape.c b/src/spatialite/virtualshape.c
+index 706b405..9899375 100644
+--- a/src/spatialite/virtualshape.c
++++ b/src/spatialite/virtualshape.c
+@@ -936,6 +936,12 @@ vshp_eval_constraints (VirtualShapeCursorPtr cursor)
+ 					      if (ret >= 0)
+ 						  ok = 1;
+ 					      break;
++#ifdef HAVE_DECL_SQLITE_INDEX_CONSTRAINT_LIKE
++					  case SQLITE_INDEX_CONSTRAINT_LIKE:
++					      if (ret >= 0)
++						  ok = 1;
++					      break;
++#endif
+ 					  };
+ 				    }
+ 				  break;


### PR DESCRIPTION
Equivalent upstream patch:
https://www.gaia-gis.it/fossil/libspatialite/info/bf5bd8b1ba
https://www.gaia-gis.it/fossil/libspatialite/vpatch?from=aa408ed10d384f46&to=bf5bd8b1ba3981f0

https://github.com/Homebrew/homebrew/pull/49680