### PR TITLE
openssl: Fix on 10.6

### DIFF
--- a/openssl/revert-pass-pure-constants-verbatim.patch
+++ b/openssl/revert-pass-pure-constants-verbatim.patch
@@ -1,0 +1,32 @@
+From 090a777f2a52da5aa7ed0c4695b2dcd73a324bea Mon Sep 17 00:00:00 2001
+From: ilovezfs <ilovezfs@icloud.com>
+Date: Sun, 6 Mar 2016 16:47:12 -0800
+Subject: [PATCH 2/2] Revert "perlasm/x86_64-xlate.pl: pass pure constants
+ verbatim."
+
+This reverts commit fd7dc201d3b9d43972de6a0e659f7ef6421c99cc.
+---
+ crypto/perlasm/x86_64-xlate.pl | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
+diff --git a/crypto/perlasm/x86_64-xlate.pl b/crypto/perlasm/x86_64-xlate.pl
+index 0a023fb..29f94b5 100755
+--- a/crypto/perlasm/x86_64-xlate.pl
++++ b/crypto/perlasm/x86_64-xlate.pl
+@@ -198,11 +198,8 @@ my %globals;
+ 	if ($gas) {
+ 	    # Solaris /usr/ccs/bin/as can't handle multiplications
+ 	    # in $self->{value}
+-	    my $value = $self->{value};
+-	    $value =~ s/(?<![\w\$\.])(0x?[0-9a-f]+)/oct($1)/egi;
+-	    if ($value =~ s/([0-9]+\s*[\*\/\%]\s*[0-9]+)/eval($1)/eg) {
+-		$self->{value} = $value;
+-	    }
++	    $self->{value} =~ s/(?<![\w\$\.])(0x?[0-9a-f]+)/oct($1)/egi;
++	    $self->{value} =~ s/([0-9]+\s*[\*\/\%]\s*[0-9]+)/eval($1)/eg;
+ 	    sprintf "\$%s",$self->{value};
+ 	} else {
+ 	    $self->{value} =~ s/(0b[0-1]+)/oct($1)/eig;
+-- 
+2.7.2
+

--- a/openssl/tshort-asm.patch
+++ b/openssl/tshort-asm.patch
@@ -1,0 +1,50 @@
+From c4af68c317c025c7d0c4f0495b8115d6426a25be Mon Sep 17 00:00:00 2001
+From: Todd Short <tshort@akamai.com>
+Date: Tue, 19 May 2015 14:46:40 -0400
+Subject: [PATCH 1/2] RT3885 OpenSSL fails to cross-compile on 32-bit->64-bit
+
+Older 32-bit versions of perl cannot handle 64-bit numbers, so when
+the x86_64-xlate.pl script encounters a 64-bit number, the oct()
+function munges it into a double-precision rather than a 64-bit
+integer. In this case, we know it's either a hex number or an octal
+number. So, if 64-bit hex, just pass through as hex string, otherwise
+allow oct() to handle it. There are some cases where immediate constants
+are multiplied together. The script assumes decimal numbers during mul,
+div, mod operations, so by handling only 64-bit numbers in this manner,
+the impact of this patch is minimized.
+
+This is a problem in ghash-x86_64.pl (ghash-x86_64.s), and the solution
+has an impact all 64-bit platforms. Ran the unit tests to make sure it's
+OK.
+---
+ crypto/perlasm/x86_64-xlate.pl | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/crypto/perlasm/x86_64-xlate.pl b/crypto/perlasm/x86_64-xlate.pl
+index aae8288..35dd501 100755
+--- a/crypto/perlasm/x86_64-xlate.pl
++++ b/crypto/perlasm/x86_64-xlate.pl
+@@ -192,13 +192,19 @@ my %globals;
+ 	}
+ 	$ret;
+     }
++    sub myoct {
++        my $v = shift;
++	return $v if ($v =~ /^0x[0-9a-f]{9,16}/i); # if 64-bit hex leave as-is
++        use integer;
++        return oct($v);
++    }
+     sub out {
+     	my $self = shift;
+ 
+ 	if ($gas) {
+ 	    # Solaris /usr/ccs/bin/as can't handle multiplications
+ 	    # in $self->{value}
+-	    $self->{value} =~ s/(?<![\w\$\.])(0x?[0-9a-f]+)/oct($1)/egi;
++	    $self->{value} =~ s/(?<![\w\$\.])(0x?[0-9a-f]+)/myoct($1)/egi;
+ 	    $self->{value} =~ s/([0-9]+\s*[\*\/\%]\s*[0-9]+)/eval($1)/eg;
+ 	    sprintf "\$%s",$self->{value};
+ 	} else {
+-- 
+2.7.2
+


### PR DESCRIPTION
This replicates Clemens Lang's work for MacPorts.
https://github.com/ryandesign/macports-ports/commit/5522f4c5b202436d6f9787cce417b1c5619cea1b

Quoting him,
  Reverts openssl's upstream commit
    openssl/openssl@fd7dc20
  and applies an alternative suggested in a pull request at
    openssl/openssl#597
  that would merge
    akamai/openssl@c4af68c