### PR TITLE
mediatomb: vendor the urifix patch

### DIFF
--- a/mediatomb/urifix.patch
+++ b/mediatomb/urifix.patch
@@ -1,0 +1,40 @@
+From 2753e70013636bb5dd4cfc595f9776d368709f04 Mon Sep 17 00:00:00 2001
+From: Sergey 'Jin' Bostandzhyan <jin at mediatomb dot cc>
+Date: Thu, 26 Dec 2013 00:50:23 +0100
+Subject: [PATCH 1/1] Workaround for Samsung TV
+
+Applied patch https://sourceforge.net/p/mediatomb/patches/37/
+---
+ tombupnp/upnp/src/genlib/net/uri/uri.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/tombupnp/upnp/src/genlib/net/uri/uri.c b/tombupnp/upnp/src/genlib/net/uri/uri.c
+index 6ad810d..071309b 100644
+--- a/tombupnp/upnp/src/genlib/net/uri/uri.c
++++ b/tombupnp/upnp/src/genlib/net/uri/uri.c
+@@ -1042,7 +1042,8 @@ parse_uri( const char *in,
+         out->path_type = REL_PATH;
+     }
+ 
+-    if( ( ( begin_hostport + 1 ) < max ) && ( in[begin_hostport] == '/' )
++    //parse hostport only if scheme was found
++    if( ( begin_hostport > 0 ) && ( ( begin_hostport + 1 ) < max ) && ( in[begin_hostport] == '/' )
+         && ( in[begin_hostport + 1] == '/' ) ) {
+         begin_hostport += 2;
+ 
+@@ -1059,6 +1060,12 @@ parse_uri( const char *in,
+         out->hostport.text.size = 0;
+         out->hostport.text.buff = 0;
+         begin_path = begin_hostport;
++
++        //remove excessive leading slashes (fix for Samsung Smart TV 2012)
++        while( ( ( begin_path + 1 ) < max ) && ( in[begin_path] == '/' ) && ( in[begin_path + 1] == '/') ) {
++            begin_path++;
++        }
++
+     }
+ 
+     begin_fragment =
+-- 
+2.8.2
+


### PR DESCRIPTION
Patch has been accepted into upstream master, but the old link now 404s.
Originally added in Homebrew/legacy-homebrew#20759.

https://sourceforge.net/p/mediatomb/code/ci/2753e70013636bb5dd4cfc595f9776d368709f04/