### PR TITLE
gperftools: prevent operator delete build failure

### DIFF
--- a/gperftools/revert-sized-delete-aliases.patch
+++ b/gperftools/revert-sized-delete-aliases.patch
@@ -1,0 +1,62 @@
+From de4abc18642a7e649baba59b64e8c97c9b2218f1 Mon Sep 17 00:00:00 2001
+From: ilovezfs <ilovezfs@icloud.com>
+Date: Fri, 13 May 2016 00:27:52 -0700
+Subject: [PATCH] Revert "build sized delete aliases even when sized-delete is
+ disabled"
+
+This reverts commit 782165fa7f2c49d6a67c2415626a1f215cc21ac2.
+---
+ configure.ac                     | 21 +++++++++++----------
+ src/libc_override_gcc_and_weak.h |  7 -------
+ 2 files changed, 11 insertions(+), 17 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 3a99b85..aa6fa2c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -351,16 +351,17 @@ AS_IF([test "x$enable_sized_delete" = xyes],
+              [AC_MSG_NOTICE([Will build dynamically detected sized deallocation operators])],
+              [AC_MSG_NOTICE([Will not build sized deallocation operators])])])
+ 
+-AC_CACHE_CHECK([if C++ compiler supports -fsized-deallocation],
+-               [perftools_cv_sized_deallocation_result],
+-               [AC_LANG_PUSH(C++)
+-                OLD_CXXFLAGS="$CXXFLAGS"
+-                CXXFLAGS="$CXXFLAGS -fsized-deallocation"
+-                AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,)],
+-                                  perftools_cv_sized_deallocation_result=yes,
+-                                  perftools_cv_sized_deallocation_result=no)
+-                CXXFLAGS="$OLD_CXXFLAGS"
+-                AC_LANG_POP(C++)])
++AS_IF([test "x$enable_sized_delete" = xyes -o "x$enable_dyn_sized_delete" = xyes],
++      [AC_CACHE_CHECK([if C++ compiler supports -fsized-deallocation],
++                      perftools_cv_sized_deallocation_result,
++                      [AC_LANG_PUSH(C++)
++                       OLD_CXXFLAGS="$CXXFLAGS"
++                       CXXFLAGS="$CXXFLAGS -fsized-deallocation"
++                       AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,)],
++                                         perftools_cv_sized_deallocation_result=yes,
++                                         perftools_cv_sized_deallocation_result=no)
++                       CXXFLAGS="$OLD_CXXFLAGS"
++                       AC_LANG_POP(C++)])])
+ 
+ AM_CONDITIONAL(HAVE_SIZED_DEALLOCATION,
+                test "$perftools_cv_sized_deallocation_result" = yes)
+diff --git a/src/libc_override_gcc_and_weak.h b/src/libc_override_gcc_and_weak.h
+index ecb66ec..ae981c4 100644
+--- a/src/libc_override_gcc_and_weak.h
++++ b/src/libc_override_gcc_and_weak.h
+@@ -127,13 +127,6 @@ void operator delete(void *p, size_t size) throw()
+ void operator delete[](void *p, size_t size) throw()
+   __attribute__((ifunc("resolve_deletearray_sized")));
+ 
+-#else /* !ENABLE_SIZED_DELETE && !ENABLE_DYN_SIZED_DELETE */
+-
+-void operator delete(void *p, size_t size) throw()
+-  ALIAS(tc_delete);
+-void operator delete[](void *p, size_t size) throw()
+-  ALIAS(tc_deletearray);
+-
+ #endif /* !ENABLE_SIZED_DELETE && !ENABLE_DYN_SIZED_DELETE */
+ 
+ extern "C" {


### PR DESCRIPTION
Reverts upstream commit
  build sized delete aliases even when sized-delete is disabled
  https://github.com/gperftools/gperftools/commit/782165fa7f2c49d6a67c2415626a1f215cc21ac2

Prevents
```
  Undefined symbols for architecture x86_64:
    "operator delete(void*, unsigned long)", referenced from:
        ProcMapsIterator::~ProcMapsIterator() in libsysinfo.a(sysinfo.o)
        ProcMapsIterator::~ProcMapsIterator() in libsysinfo.a(sysinfo.o)
        tcmalloc::FillProcSelfMaps(char*, int, bool*) in libsysinfo.a(sysinfo.o)
        tcmalloc::DumpProcSelfMaps(int) in libsysinfo.a(sysinfo.o)
```
Workaround for https://github.com/gperftools/gperftools/issues/794

See Homebrew/homebrew-core#383.